### PR TITLE
log in users must be unique user objects have pfp key and posts key

### DIFF
--- a/socialapp/app/componants/AuthBox.jsx
+++ b/socialapp/app/componants/AuthBox.jsx
@@ -15,7 +15,7 @@ const AuthBox = () => {
      }
      
      useEffect(() => {
-          const userList = JSON.parse(localStorage.getItem('user'));
+          const userList = JSON.parse(localStorage.getItem('users'));
           if (!userList) return;
           setUsers(userList);
      }, [])
@@ -49,6 +49,7 @@ const AuthBox = () => {
           event.preventDefault();
           if (!userObject.name || !userObject.password) {
                console.log("there is an error no input");
+               return
           }
           checkInput()
      };

--- a/socialapp/app/componants/UserCreateBox.jsx
+++ b/socialapp/app/componants/UserCreateBox.jsx
@@ -1,7 +1,7 @@
 'use client';
 import {useState, useEffect} from 'react'
 const UserCreateBox = () => {
-const [userObject, setuserObject] = useState({})
+const [userObject, setuserObject] = useState({name:"", password:"", password2:"" , posts:[], PFP: ""})
 const [isSuccess, setIsSuccess] = useState(false)
 const [isError, setIsError] = useState(false)
 const [user, setUser] = useState([])
@@ -13,7 +13,11 @@ const handleInputChange = (event) => {
 		[event.target.name]: event.target.value
 	})
 }
-
+const setCurrentUser = () => {
+	const currentUser = {name : userObject.name , password : userObject.password};
+	localStorage.setItem('currentUser', JSON.stringify(currentUser));
+	return console.log(currentUser);
+};
 const resetInputs = () =>  {
      const inputs = document.getElementById("my-form").elements;
 
@@ -37,19 +41,24 @@ const resetInputs = () =>  {
 			}, 3000);
 			return;
 		}
-		if(userObject.password == userObject.password2){
+		for(let i in user){
+			if(user[i].name == userObject.name){return console.log("user exists")}
+		}
+		if(userObject.password == userObject.password2 && /^(?=.*[a-zA-Z0-9])(?=.*[\W_]).{8,20}$/g.test(userObject.password) == true ){
+			setCurrentUser()
 			setUser((prevUser) => {
 				const updatedUser = [...prevUser, userObject];
 				localStorage.setItem('user', JSON.stringify(updatedUser));
 				return updatedUser;
 			});
+			
 			setIsSuccess(true);
 			setuserObject({});
 			setTimeout(() => {
 				resetInputs();
 				setIsSuccess(false);
 			}, 3000);
-		}
+		}return document.location.href=("./profilePage")
 	};
   	return (
 		<div>


### PR DESCRIPTION
The username of each user must be unique. stopping multiple account from having the same name and password and errors from occurring. user objects now have PFP key for the url for a picture as well as an array for all their posts to be shown on the profile page.